### PR TITLE
Support for `python>=3.8`

### DIFF
--- a/.github/workflows/check_releasable.yml
+++ b/.github/workflows/check_releasable.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run tests
         run: |
-          poetry run pytest -vv
+          poetry run pytest -vvv
 
       - name: Append Build Number to version
         id: version
@@ -68,31 +68,49 @@ jobs:
     needs: check_releasable
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
     steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Create & Activate a virtual environment
         run: |
           python3 -m venv venv2
           source venv2/bin/activate
+          python --version
 
       - name: Install published package
         continue-on-error: true
         run: |
+          pip install --upgrade pip
           sleep 10
           pip3 install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "sign-language-translator==${{ needs.check_releasable.outputs.package_version }}"
           pip3 show sign-language-translator
 
       - name: Retry Install published package after Delay
-        if: failure()
+        if: always()
         run: |
-          echo "Retrying installation in 100 seconds..."
-          sleep 100
-          pip3 install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "sign-language-translator==${{ needs.check_releasable.outputs.package_version }}"
-          pip3 show sign-language-translator
+          if ! pip3 show sign-language-translator &> /dev/null; then
+            echo "Retrying installation in 100 seconds..."
+            sleep 100
+            pip3 install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "sign-language-translator==${{ needs.check_releasable.outputs.package_version }}"
+            pip3 show sign-language-translator
+          fi
 
       - name: Run Package CLI
         if: success()
         run: |
           slt complete "<" --model-code urdu-mixed-ngram -w 1.0 --model-code ur-supported-gpt -w 1.5 --join ""
+
+      - name: Run Package Python API
+        if: success()
+        run: |
+          python3 -c "import sign_language_translator as slt; print(slt.__version__); model = slt.models.ConcatenativeSynthesis(text_language='urdu', sign_language='pk-sl', sign_format='video'); sign = model.translate('یہ بہت اچھا ہے۔'); print(len(sign));"
 
         # BUG: OpenCV not writing videos on github actions: global cap_ffmpeg_impl.hpp:3018 open Could not find encoder for codec_id=27, error: Encoder not found
         # slt translate "SLT" --model-code rule-based --text-lang ur --sign-lang pk-sl --sign-format video --display false --save-format avi

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ![Release Workflow Status](https://img.shields.io/github/actions/workflow/status/sign-language-translator/sign-language-translator/release.yml?branch=main&logo=pytest)
 [![codecov](https://codecov.io/gh/sign-language-translator/sign-language-translator/branch/main/graph/badge.svg)](https://codecov.io/gh/sign-language-translator/sign-language-translator)
 [![Documentation Status](https://img.shields.io/readthedocs/sign-language-translator?logo=readthedocs&)](https://sign-language-translator.readthedocs.io/)
-![GitHub Repo stars](https://img.shields.io/github/stars/sign-language-translator/sign-language-translator?logo=github)
+[![GitHub Repo stars](https://img.shields.io/github/stars/sign-language-translator/sign-language-translator?logo=github)](https://github.com/sign-language-translator/sign-language-translator/stargazers)
 
 </div>
 
@@ -180,7 +180,7 @@ pip install sign-language-translator
 ```
 
 <details>
-<summary>Editable mode:</summary>
+<summary>Editable mode (<code>git clone</code>):</summary>
 
 ```bash
 git clone https://github.com/sign-language-translator/sign-language-translator.git
@@ -219,8 +219,8 @@ sign = model.translate(text) # tokenize, map, download & concatenate
 sign.show()
 # sign.save(f"{text}.mp4")
 
-model.text_language = "hindi"
-sign = model.translate("पाँच घंटे।") # "5 hours."
+# model.text_language = "hindi"
+# sign = model.translate("पाँच घंटे।") # "5 hours."
 ```
 
 ![this very good is](https://github.com/sign-language-translator/sign-language-translator/assets/118578823/7f4ff312-df03-4b11-837b-5fb895c9f08e)
@@ -286,10 +286,10 @@ Available Functions:
 - Token Classification (Tagging)
 - Word Sense Disambiguation
 
-| Name                                                                                                                                   | Vocabulary         | Ambiguous tokens | Signs |
-| -------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ---------------- | ----- |
-| [Urdu](https://github.com/sign-language-translator/sign-language-translator/blob/main/sign_language_translator/languages/text/urdu.py) | 2090 words+phrases | 227              | 790   |
-| [Hindi](https://github.com/sign-language-translator/sign-language-translator/blob/main/sign_language_translator/languages/text/hindi.py) | 34 words+phrases | 5              | 16   |
+| Name                                                                                                                                     | Vocabulary         | Ambiguous tokens | Signs |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ---------------- | ----- |
+| [Urdu](https://github.com/sign-language-translator/sign-language-translator/blob/main/sign_language_translator/languages/text/urdu.py)   | 2090 words+phrases | 227              | 790   |
+| [Hindi](https://github.com/sign-language-translator/sign-language-translator/blob/main/sign_language_translator/languages/text/hindi.py) | 34 words+phrases   | 5                | 16    |
 
 </details>
 
@@ -302,8 +302,8 @@ Available Functions:
 - Sentence restructuring according to grammar
 - Sentence simplification (drop stopwords)
 
-| Name                                                                                                                                                                       | Vocabulary | Dataset | Parallel Corpus                                               |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------- | ------------------------------------------------------------- |
+| Name                                                                                                                                                                       | Vocabulary | Dataset  | Parallel Corpus                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | ------------------------------------------------------- |
 | [Pakistan Sign Language](https://github.com/sign-language-translator/sign-language-translator/blob/main/sign_language_translator/languages/sign/pakistan_sign_language.py) | 789        | 23 hours | n gloss sentences with translations in m text languages |
 
 </details>
@@ -433,7 +433,7 @@ Remember to contribute back to the community:
 - Share your data, code, and models by creating a pull request (PR), allowing others to benefit from your efforts.
 - Create your own sign language translator (e.g. as your university thesis) and contribute to a more inclusive and accessible world.
 
-See the code at [Build Custom Translator section in ReadTheDocs](https://sign-language-translator.readthedocs.io/en/latest/#building-custom-translators) or in this [notebook](https://github.com/sign-language-translator/notebooks/blob/main/translation/concatenative_synthesis.ipynb). [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sign-language-translator/notebooks/blob/main/translation/concatenative_synthesis.ipynb)
+See the `code` at [Build Custom Translator section in ReadTheDocs](https://sign-language-translator.readthedocs.io/en/latest/#building-custom-translators) or in this [notebook](https://github.com/sign-language-translator/notebooks/blob/main/translation/concatenative_synthesis.ipynb). [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sign-language-translator/notebooks/blob/main/translation/concatenative_synthesis.ipynb)
 
 ## Directory Tree
 
@@ -578,11 +578,9 @@ Stay Tuned!
 ## Upcoming/Roadmap
 
 <details>
-<summary>TEXT_PROCESSING_IMPROVEMENTS: v0.7</summary>
+<summary>TEXT_EMBEDDING: v0.7</summary>
 
 ```python
-# improve urdu code
-# add `hindi.py` (NotImplementedError) + `english.py`
 # text embedding models
 # synonyms by similarity
 ```
@@ -608,7 +606,8 @@ Stay Tuned!
 <summary>LANGUAGES: v0.9</summary>
 
 ```python
-# implement NLP classes for English & Hindi
+# improve Urdu code
+# implement NLP class for English
 # expand dictionary video data by scraping everything
 ```
 
@@ -676,7 +675,7 @@ Stay Tuned!
 
 ## Credits and Gratitude
 
-This project started in October 2021 as a BS Computer Science final year project with 3 students and 1 supervisor. After 9 months at university, it became a hobby project for Mudassar who has continued it till at least 2024-01-15.
+This project started in October 2021 as a BS Computer Science final year project with 3 students and 1 supervisor. After 9 months at university, it became a hobby project for Mudassar who has continued it till at least 2024-01-17.
 
 <details>
 <summary> Immense gratitude towards: (click to expand)</summary>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,10 +51,12 @@ intersphinx_mapping = {
 
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+from typing import Optional
+
 import requests
 
 
-def linkcode_resolve(domain, info) -> str | None:
+def linkcode_resolve(domain, info) -> Optional[str]:
     """
     Generates a URL for the given domain and module information.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -634,52 +634,58 @@ files = [
 
 [[package]]
 name = "matplotlib"
-version = "3.7.2"
+version = "3.7.4"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "matplotlib-3.7.2-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:2699f7e73a76d4c110f4f25be9d2496d6ab4f17345307738557d345f099e07de"},
-    {file = "matplotlib-3.7.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a8035ba590658bae7562786c9cc6ea1a84aa49d3afab157e414c9e2ea74f496d"},
-    {file = "matplotlib-3.7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2f8e4a49493add46ad4a8c92f63e19d548b2b6ebbed75c6b4c7f46f57d36cdd1"},
-    {file = "matplotlib-3.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71667eb2ccca4c3537d9414b1bc00554cb7f91527c17ee4ec38027201f8f1603"},
-    {file = "matplotlib-3.7.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:152ee0b569a37630d8628534c628456b28686e085d51394da6b71ef84c4da201"},
-    {file = "matplotlib-3.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:070f8dddd1f5939e60aacb8fa08f19551f4b0140fab16a3669d5cd6e9cb28fc8"},
-    {file = "matplotlib-3.7.2-cp310-cp310-win32.whl", hash = "sha256:fdbb46fad4fb47443b5b8ac76904b2e7a66556844f33370861b4788db0f8816a"},
-    {file = "matplotlib-3.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:23fb1750934e5f0128f9423db27c474aa32534cec21f7b2153262b066a581fd1"},
-    {file = "matplotlib-3.7.2-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:30e1409b857aa8a747c5d4f85f63a79e479835f8dffc52992ac1f3f25837b544"},
-    {file = "matplotlib-3.7.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:50e0a55ec74bf2d7a0ebf50ac580a209582c2dd0f7ab51bc270f1b4a0027454e"},
-    {file = "matplotlib-3.7.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ac60daa1dc83e8821eed155796b0f7888b6b916cf61d620a4ddd8200ac70cd64"},
-    {file = "matplotlib-3.7.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305e3da477dc8607336ba10bac96986d6308d614706cae2efe7d3ffa60465b24"},
-    {file = "matplotlib-3.7.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c308b255efb9b06b23874236ec0f10f026673ad6515f602027cc8ac7805352d"},
-    {file = "matplotlib-3.7.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60c521e21031632aa0d87ca5ba0c1c05f3daacadb34c093585a0be6780f698e4"},
-    {file = "matplotlib-3.7.2-cp311-cp311-win32.whl", hash = "sha256:26bede320d77e469fdf1bde212de0ec889169b04f7f1179b8930d66f82b30cbc"},
-    {file = "matplotlib-3.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:af4860132c8c05261a5f5f8467f1b269bf1c7c23902d75f2be57c4a7f2394b3e"},
-    {file = "matplotlib-3.7.2-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:a1733b8e84e7e40a9853e505fe68cc54339f97273bdfe6f3ed980095f769ddc7"},
-    {file = "matplotlib-3.7.2-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:d9881356dc48e58910c53af82b57183879129fa30492be69058c5b0d9fddf391"},
-    {file = "matplotlib-3.7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f081c03f413f59390a80b3e351cc2b2ea0205839714dbc364519bcf51f4b56ca"},
-    {file = "matplotlib-3.7.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1cd120fca3407a225168238b790bd5c528f0fafde6172b140a2f3ab7a4ea63e9"},
-    {file = "matplotlib-3.7.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a2c1590b90aa7bd741b54c62b78de05d4186271e34e2377e0289d943b3522273"},
-    {file = "matplotlib-3.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d2ff3c984b8a569bc1383cd468fc06b70d7b59d5c2854ca39f1436ae8394117"},
-    {file = "matplotlib-3.7.2-cp38-cp38-win32.whl", hash = "sha256:5dea00b62d28654b71ca92463656d80646675628d0828e08a5f3b57e12869e13"},
-    {file = "matplotlib-3.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:0f506a1776ee94f9e131af1ac6efa6e5bc7cb606a3e389b0ccb6e657f60bb676"},
-    {file = "matplotlib-3.7.2-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:6515e878f91894c2e4340d81f0911857998ccaf04dbc1bba781e3d89cbf70608"},
-    {file = "matplotlib-3.7.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:71f7a8c6b124e904db550f5b9fe483d28b896d4135e45c4ea381ad3b8a0e3256"},
-    {file = "matplotlib-3.7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:12f01b92ecd518e0697da4d97d163b2b3aa55eb3eb4e2c98235b3396d7dad55f"},
-    {file = "matplotlib-3.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7e28d6396563955f7af437894a36bf2b279462239a41028323e04b85179058b"},
-    {file = "matplotlib-3.7.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dbcf59334ff645e6a67cd5f78b4b2cdb76384cdf587fa0d2dc85f634a72e1a3e"},
-    {file = "matplotlib-3.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:318c89edde72ff95d8df67d82aca03861240512994a597a435a1011ba18dbc7f"},
-    {file = "matplotlib-3.7.2-cp39-cp39-win32.whl", hash = "sha256:ce55289d5659b5b12b3db4dc9b7075b70cef5631e56530f14b2945e8836f2d20"},
-    {file = "matplotlib-3.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:2ecb5be2b2815431c81dc115667e33da0f5a1bcf6143980d180d09a717c4a12e"},
-    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:fdcd28360dbb6203fb5219b1a5658df226ac9bebc2542a9e8f457de959d713d0"},
-    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c3cca3e842b11b55b52c6fb8bd6a4088693829acbfcdb3e815fa9b7d5c92c1b"},
-    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebf577c7a6744e9e1bd3fee45fc74a02710b214f94e2bde344912d85e0c9af7c"},
-    {file = "matplotlib-3.7.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:936bba394682049919dda062d33435b3be211dc3dcaa011e09634f060ec878b2"},
-    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bc221ffbc2150458b1cd71cdd9ddd5bb37962b036e41b8be258280b5b01da1dd"},
-    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35d74ebdb3f71f112b36c2629cf32323adfbf42679e2751252acd468f5001c07"},
-    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:717157e61b3a71d3d26ad4e1770dc85156c9af435659a25ee6407dc866cb258d"},
-    {file = "matplotlib-3.7.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:20f844d6be031948148ba49605c8b96dfe7d3711d1b63592830d650622458c11"},
-    {file = "matplotlib-3.7.2.tar.gz", hash = "sha256:a8cdb91dddb04436bd2f098b8fdf4b81352e68cf4d2c6756fcc414791076569b"},
+    {file = "matplotlib-3.7.4-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:b71079239bd866bf56df023e5146de159cb0c7294e508830901f4d79e2d89385"},
+    {file = "matplotlib-3.7.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bf91a42f6274a64cb41189120b620c02e574535ff6671fa836cade7701b06fbd"},
+    {file = "matplotlib-3.7.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f757e8b42841d6add0cb69b42497667f0d25a404dcd50bd923ec9904e38414c4"},
+    {file = "matplotlib-3.7.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4dfee00aa4bd291e08bb9461831c26ce0da85ca9781bb8794f2025c6e925281"},
+    {file = "matplotlib-3.7.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3640f33632beb3993b698b1be9d1c262b742761d6101f3c27b87b2185d25c875"},
+    {file = "matplotlib-3.7.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff539c4a17ecdf076ed808ee271ffae4a30dcb7e157b99ccae2c837262c07db6"},
+    {file = "matplotlib-3.7.4-cp310-cp310-win32.whl", hash = "sha256:24b8f28af3e766195c09b780b15aa9f6710192b415ae7866b9c03dee7ec86370"},
+    {file = "matplotlib-3.7.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fa193286712c3b6c3cfa5fe8a6bb563f8c52cc750006c782296e0807ce5e799"},
+    {file = "matplotlib-3.7.4-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:b167f54cb4654b210c9624ec7b54e2b3b8de68c93a14668937e7e53df60770ec"},
+    {file = "matplotlib-3.7.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7dfe6821f1944cb35603ff22e21510941bbcce7ccf96095beffaac890d39ce77"},
+    {file = "matplotlib-3.7.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3c557d9165320dff3c5f2bb99bfa0b6813d3e626423ff71c40d6bc23b83c3339"},
+    {file = "matplotlib-3.7.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08372696b3bb45c563472a552a705bfa0942f0a8ffe084db8a4e8f9153fbdf9d"},
+    {file = "matplotlib-3.7.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81e1a7ac818000e8ac3ca696c3fdc501bc2d3adc89005e7b4e22ee5e9d51de98"},
+    {file = "matplotlib-3.7.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:390920a3949906bc4b0216198d378f2a640c36c622e3584dd0c79a7c59ae9f50"},
+    {file = "matplotlib-3.7.4-cp311-cp311-win32.whl", hash = "sha256:62e094d8da26294634da9e7f1856beee3978752b1b530c8e1763d2faed60cc10"},
+    {file = "matplotlib-3.7.4-cp311-cp311-win_amd64.whl", hash = "sha256:f8fc2df756105784e650605e024d36dc2d048d68e5c1b26df97ee25d1bd41f9f"},
+    {file = "matplotlib-3.7.4-cp312-cp312-macosx_10_12_universal2.whl", hash = "sha256:568574756127791903604e315c11aef9f255151e4cfe20ec603a70f9dda8e259"},
+    {file = "matplotlib-3.7.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:7d479aac338195e2199a8cfc03c4f2f55914e6a120177edae79e0340a6406457"},
+    {file = "matplotlib-3.7.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:32183d4be84189a4c52b4b8861434d427d9118db2cec32986f98ed6c02dcfbb6"},
+    {file = "matplotlib-3.7.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0037d066cca1f4bda626c507cddeb6f7da8283bc6a214da2db13ff2162933c52"},
+    {file = "matplotlib-3.7.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44856632ebce88abd8efdc0a0dceec600418dcac06b72ae77af0019d260aa243"},
+    {file = "matplotlib-3.7.4-cp312-cp312-win_amd64.whl", hash = "sha256:632fc938c22117d4241411191cfb88ac264a4c0a9ac702244641ddf30f0d739c"},
+    {file = "matplotlib-3.7.4-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:ce163be048613b9d1962273708cc97e09ca05d37312e670d166cf332b80bbaff"},
+    {file = "matplotlib-3.7.4-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:e680f49bb8052ba3b2698e370155d2b4afb49f9af1cc611a26579d5981e2852a"},
+    {file = "matplotlib-3.7.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0604880e4327114054199108b7390f987f4f40ee5ce728985836889e11a780ba"},
+    {file = "matplotlib-3.7.4-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1e6abcde6fc52475f9d6a12b9f1792aee171ce7818ef6df5d61cb0b82816e6e8"},
+    {file = "matplotlib-3.7.4-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f59a70e2ec3212033ef6633ed07682da03f5249379722512a3a2a26a7d9a738e"},
+    {file = "matplotlib-3.7.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a9981b2a2dd9da06eca4ab5855d09b54b8ce7377c3e0e3957767b83219d652d"},
+    {file = "matplotlib-3.7.4-cp38-cp38-win32.whl", hash = "sha256:83859ac26839660ecd164ee8311272074250b915ac300f9b2eccc84410f8953b"},
+    {file = "matplotlib-3.7.4-cp38-cp38-win_amd64.whl", hash = "sha256:7a7709796ac59fe8debde68272388be6ed449c8971362eb5b60d280eac8dadde"},
+    {file = "matplotlib-3.7.4-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:b1d70bc1ea1bf110bec64f4578de3e14947909a8887df4c1fd44492eca487955"},
+    {file = "matplotlib-3.7.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c83f49e795a5de6c168876eea723f5b88355202f9603c55977f5356213aa8280"},
+    {file = "matplotlib-3.7.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5c9133f230945fe10652eb33e43642e933896194ef6a4f8d5e79bb722bdb2000"},
+    {file = "matplotlib-3.7.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:798ff59022eeb276380ce9a73ba35d13c3d1499ab9b73d194fd07f1b0a41c304"},
+    {file = "matplotlib-3.7.4-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1707b20b25e90538c2ce8d4409e30f0ef1df4017cc65ad0439633492a973635b"},
+    {file = "matplotlib-3.7.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e6227ca8492baeef873cdd8e169a318efb5c3a25ce94e69727e7f964995b0b1"},
+    {file = "matplotlib-3.7.4-cp39-cp39-win32.whl", hash = "sha256:5661c8639aded7d1bbf781373a359011cb1dd09199dee49043e9e68dd16f07ba"},
+    {file = "matplotlib-3.7.4-cp39-cp39-win_amd64.whl", hash = "sha256:55eec941a4743f0bd3e5b8ee180e36b7ea8e62f867bf2613937c9f01b9ac06a2"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ab16868714e5cc90ec8f7ff5d83d23bcd6559224d8e9cb5227c9f58748889fe8"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c698b33f9a3f0b127a8e614c8fb4087563bb3caa9c9d95298722fa2400cdd3f"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be3493bbcb4d255cb71de1f9050ac71682fce21a56089eadbcc8e21784cb12ee"},
+    {file = "matplotlib-3.7.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:f8c725d1dd2901b2e7ec6cd64165e00da2978cc23d4143cb9ef745bec88e6b04"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:286332f8f45f8ffde2d2119b9fdd42153dccd5025fa9f451b4a3b5c086e26da5"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:116ef0b43aa00ff69260b4cce39c571e4b8c6f893795b708303fa27d9b9d7548"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c90590d4b46458677d80bc3218f3f1ac11fc122baa9134e0cb5b3e8fc3714052"},
+    {file = "matplotlib-3.7.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:de7c07069687be64fd9d119da3122ba13a8d399eccd3f844815f0dc78a870b2c"},
+    {file = "matplotlib-3.7.4.tar.gz", hash = "sha256:7cd4fef8187d1dd0d9dcfdbaa06ac326d396fb8c71c647129f0bf56835d77026"},
 ]
 
 [package.dependencies]
@@ -688,35 +694,39 @@ cycler = ">=0.10"
 fonttools = ">=4.22.0"
 importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
 kiwisolver = ">=1.0.1"
-numpy = ">=1.20"
+numpy = ">=1.20,<2"
 packaging = ">=20.0"
 pillow = ">=6.2.0"
-pyparsing = ">=2.3.1,<3.1"
+pyparsing = ">=2.3.1"
 python-dateutil = ">=2.7"
 
 [[package]]
 name = "mediapipe"
-version = "0.10.3"
+version = "0.10.9"
 description = "MediaPipe is the simplest way for researchers and developers to build world-class ML solutions and applications for mobile, edge, cloud and the web."
 optional = false
 python-versions = "*"
 files = [
-    {file = "mediapipe-0.10.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1503517f8d2be93b99a7f2735c59dafa2bbaf2b98d29cc83a142bc01e0c72d01"},
-    {file = "mediapipe-0.10.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84240ae8edd28eba8d3ffa4636178063473b207a416a65d09c19ee1cd9454cbc"},
-    {file = "mediapipe-0.10.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e47cd06fe25a52add5c0bbcd8643c8b03677c98ff3a96f8e3c122ac148d63161"},
-    {file = "mediapipe-0.10.3-cp310-cp310-win_amd64.whl", hash = "sha256:370627ea1f8c6be9dbde832aa2bae8f163eb150b7460c1f96ac57ee4c5a7807c"},
-    {file = "mediapipe-0.10.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:df191730be853d8a2afc2b18c8e3f174caa14242a56082f6a84c9d038a6b21a5"},
-    {file = "mediapipe-0.10.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83552d129d145ab88dcae742d3ae6ab37fdcd18bdf6efd5b50d3d231598e86f5"},
-    {file = "mediapipe-0.10.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbcb2b414443d1c17e8f20f10b69d7b1113f21acff4ee1aada8e97521df71783"},
-    {file = "mediapipe-0.10.3-cp311-cp311-win_amd64.whl", hash = "sha256:f3b6178203200c4a9b1829bd2fa93cef55d439418b26c278c3efa6529334c837"},
-    {file = "mediapipe-0.10.3-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:12d11e800038fbbc231d8e0cec9bf92f0676d580741b3d699aeb6339e8a7c09f"},
-    {file = "mediapipe-0.10.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05a3cf6038c832f3a9d4906f63d39bd1338c22898677620b3035394a29c68fde"},
-    {file = "mediapipe-0.10.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f09dd2950f83125b5d720b4e3c24c62cf74968ada3832314816c52eca237564e"},
-    {file = "mediapipe-0.10.3-cp38-cp38-win_amd64.whl", hash = "sha256:6aadc67c8471fc93b117e87fff50100799960eb0510d4c4f15a1c7bf56a8ef25"},
-    {file = "mediapipe-0.10.3-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:cbfa658051bf3294f40ceddbbf5d4a71726e6637345895f3b02ce4442ed82ee9"},
-    {file = "mediapipe-0.10.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3fa2ad9ad29906c5705eee8c6af2a84a15bd2be236f584df56f8c389f2b3f41"},
-    {file = "mediapipe-0.10.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3e93d062bb28c9807cbe4c6482fad91b7eeff8164850789884b9c6352c170d4"},
-    {file = "mediapipe-0.10.3-cp39-cp39-win_amd64.whl", hash = "sha256:5bd13d26c212c5508dbfd73dd3e8874919c730ff0dcde272658499a90fa7f3cd"},
+    {file = "mediapipe-0.10.9-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:ae078678d60e84861291973402ad1f21d500d67b3265327d9789af3e17af5a9a"},
+    {file = "mediapipe-0.10.9-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:33dfe3061b1e26350eb68a6d13555400cf0e03acd02420f432c907116ca1c83e"},
+    {file = "mediapipe-0.10.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f21a0af8dd35747ffbcec1086f74eefbf8e96cd285bba327a67580e315c52da0"},
+    {file = "mediapipe-0.10.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84c7ab49c7ece1f0246b4f066cdc3089ff1a0b13f67c3fd23b81dfd907f58057"},
+    {file = "mediapipe-0.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:fcf2ff891171c1c704a28cad16e9af31121d85468f87c46c277aa5ac86f96bcf"},
+    {file = "mediapipe-0.10.9-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8733735f582e6e6a05bf9b15c48b03a6387a0795793a2530aa1189eecfd33780"},
+    {file = "mediapipe-0.10.9-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:b7dde54b82732479b9b856c9230b9f7b3da55b0913dde5254a7489e20c2e3c6e"},
+    {file = "mediapipe-0.10.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4eefd799812d81f1a4ab06554dda42b0bfe91a7fe16fb793687175035c5adeb"},
+    {file = "mediapipe-0.10.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c31ea1160c118daa50f7d43f0027d2480664568df53b7d7a7835b6e966f2cc2"},
+    {file = "mediapipe-0.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:ad98a5783c4bef69d66a90e3c0140eab999d03178d637b2450aa415276fe32ba"},
+    {file = "mediapipe-0.10.9-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:f99bc1beb4de89008693134809d6351aa1531acfc7b0ae1ece4a3b7d171aa495"},
+    {file = "mediapipe-0.10.9-cp38-cp38-macosx_11_0_x86_64.whl", hash = "sha256:c27594c51a8cbebcf383c8d41fb230daac30f755a9f83c9f2bb5c686461a1fff"},
+    {file = "mediapipe-0.10.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d15e69a1d79db7f205ab2e03c86327bc0440ec9e206cc0a6994a82bf819731ef"},
+    {file = "mediapipe-0.10.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f9a120c3abbb05d961c137931ac0a2b9276fe11380b35939bde7c615d5da95a"},
+    {file = "mediapipe-0.10.9-cp38-cp38-win_amd64.whl", hash = "sha256:ec35aa2155432becbfd6f2499c2ce266e171a295ba19c4dcf8c85bc8d4208398"},
+    {file = "mediapipe-0.10.9-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a6f84f7920dd6853f3c092c95669a2c1c6e0593cbcf4f00f75bcf3401458dd7e"},
+    {file = "mediapipe-0.10.9-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:7122251d30acb70ec5570bd9ee0d87ef53c8bb9086fa269c8d6a94432778e3b6"},
+    {file = "mediapipe-0.10.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abe2daef17502630a355cc08cb3fb562db1cc8c64af52d15f23551ff6968756b"},
+    {file = "mediapipe-0.10.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a0f3cd14482c97b27b91edc595c2570195e55983acf8c3db585b0382c0df75"},
+    {file = "mediapipe-0.10.9-cp39-cp39-win_amd64.whl", hash = "sha256:241732ef315fd45c0a3d3e7e264d0416bba3fb462563bc903fb526ec5c944123"},
 ]
 
 [package.dependencies]
@@ -766,36 +776,39 @@ test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "numpy"
-version = "1.25.2"
+version = "1.24.4"
 description = "Fundamental package for array computing in Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 files = [
-    {file = "numpy-1.25.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:db3ccc4e37a6873045580d413fe79b68e47a681af8db2e046f1dacfa11f86eb3"},
-    {file = "numpy-1.25.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:90319e4f002795ccfc9050110bbbaa16c944b1c37c0baeea43c5fb881693ae1f"},
-    {file = "numpy-1.25.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dfe4a913e29b418d096e696ddd422d8a5d13ffba4ea91f9f60440a3b759b0187"},
-    {file = "numpy-1.25.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08f2e037bba04e707eebf4bc934f1972a315c883a9e0ebfa8a7756eabf9e357"},
-    {file = "numpy-1.25.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bec1e7213c7cb00d67093247f8c4db156fd03075f49876957dca4711306d39c9"},
-    {file = "numpy-1.25.2-cp310-cp310-win32.whl", hash = "sha256:7dc869c0c75988e1c693d0e2d5b26034644399dd929bc049db55395b1379e044"},
-    {file = "numpy-1.25.2-cp310-cp310-win_amd64.whl", hash = "sha256:834b386f2b8210dca38c71a6e0f4fd6922f7d3fcff935dbe3a570945acb1b545"},
-    {file = "numpy-1.25.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c5462d19336db4560041517dbb7759c21d181a67cb01b36ca109b2ae37d32418"},
-    {file = "numpy-1.25.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5652ea24d33585ea39eb6a6a15dac87a1206a692719ff45d53c5282e66d4a8f"},
-    {file = "numpy-1.25.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d60fbae8e0019865fc4784745814cff1c421df5afee233db6d88ab4f14655a2"},
-    {file = "numpy-1.25.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60e7f0f7f6d0eee8364b9a6304c2845b9c491ac706048c7e8cf47b83123b8dbf"},
-    {file = "numpy-1.25.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bb33d5a1cf360304754913a350edda36d5b8c5331a8237268c48f91253c3a364"},
-    {file = "numpy-1.25.2-cp311-cp311-win32.whl", hash = "sha256:5883c06bb92f2e6c8181df7b39971a5fb436288db58b5a1c3967702d4278691d"},
-    {file = "numpy-1.25.2-cp311-cp311-win_amd64.whl", hash = "sha256:5c97325a0ba6f9d041feb9390924614b60b99209a71a69c876f71052521d42a4"},
-    {file = "numpy-1.25.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b79e513d7aac42ae918db3ad1341a015488530d0bb2a6abcbdd10a3a829ccfd3"},
-    {file = "numpy-1.25.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eb942bfb6f84df5ce05dbf4b46673ffed0d3da59f13635ea9b926af3deb76926"},
-    {file = "numpy-1.25.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e0746410e73384e70d286f93abf2520035250aad8c5714240b0492a7302fdca"},
-    {file = "numpy-1.25.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7806500e4f5bdd04095e849265e55de20d8cc4b661b038957354327f6d9b295"},
-    {file = "numpy-1.25.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8b77775f4b7df768967a7c8b3567e309f617dd5e99aeb886fa14dc1a0791141f"},
-    {file = "numpy-1.25.2-cp39-cp39-win32.whl", hash = "sha256:2792d23d62ec51e50ce4d4b7d73de8f67a2fd3ea710dcbc8563a51a03fb07b01"},
-    {file = "numpy-1.25.2-cp39-cp39-win_amd64.whl", hash = "sha256:76b4115d42a7dfc5d485d358728cdd8719be33cc5ec6ec08632a5d6fca2ed380"},
-    {file = "numpy-1.25.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1a1329e26f46230bf77b02cc19e900db9b52f398d6722ca853349a782d4cff55"},
-    {file = "numpy-1.25.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c3abc71e8b6edba80a01a52e66d83c5d14433cbcd26a40c329ec7ed09f37901"},
-    {file = "numpy-1.25.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1b9735c27cea5d995496f46a8b1cd7b408b3f34b6d50459d9ac8fe3a20cc17bf"},
-    {file = "numpy-1.25.2.tar.gz", hash = "sha256:fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64"},
+    {file = "numpy-1.24.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4"},
+    {file = "numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6"},
+    {file = "numpy-1.24.4-cp310-cp310-win32.whl", hash = "sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc"},
+    {file = "numpy-1.24.4-cp310-cp310-win_amd64.whl", hash = "sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810"},
+    {file = "numpy-1.24.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7"},
+    {file = "numpy-1.24.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5"},
+    {file = "numpy-1.24.4-cp311-cp311-win32.whl", hash = "sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d"},
+    {file = "numpy-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61"},
+    {file = "numpy-1.24.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e"},
+    {file = "numpy-1.24.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc"},
+    {file = "numpy-1.24.4-cp38-cp38-win32.whl", hash = "sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2"},
+    {file = "numpy-1.24.4-cp38-cp38-win_amd64.whl", hash = "sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400"},
+    {file = "numpy-1.24.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"},
+    {file = "numpy-1.24.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d"},
+    {file = "numpy-1.24.4-cp39-cp39-win32.whl", hash = "sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835"},
+    {file = "numpy-1.24.4-cp39-cp39-win_amd64.whl", hash = "sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a"},
+    {file = "numpy-1.24.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2"},
+    {file = "numpy-1.24.4.tar.gz", hash = "sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463"},
 ]
 
 [[package]]
@@ -1334,5 +1347,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.13"
-content-hash = "9642d9cece8b2ce69e18843e03c2a250b06ac7e2077bf28186c25249f0259a50"
+python-versions = ">=3.8,<3.12"
+content-hash = "6c5032d2e927c6d79f18a261edfb0a38c74870394a1d1ecb8e90b63930c02302"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ documentation = "https://sign-language-translator.readthedocs.io/en/latest/"
 keywords = ["sign-language", "sign-language-translation", "nlp", "computer-vision", "deep-learning", "ai", "translation", "translator", "sign-language-translator", "rule-based"]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
-matplotlib = "^3.7.2"
-mediapipe = "0.10.3"
-numpy = "^1.25.1"
-torch = "^2.1.2"
+python = ">=3.8,<3.12"
+matplotlib = "^3.7.4"
+mediapipe = "==0.10.*"
+numpy = "==1.24.*"
+torch = "==2.1.*"
 deep-translator = "^1.11.4"
 opencv-contrib-python = "^4.8.0.74"
 tqdm = "^4.65.0"

--- a/sign_language_translator/config/assets.py
+++ b/sign_language_translator/config/assets.py
@@ -7,7 +7,7 @@ import os
 import re
 from datetime import datetime
 from os.path import abspath, dirname, exists, isdir, isfile, join, sep
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from tqdm.auto import tqdm
 
@@ -38,10 +38,10 @@ class Assets:
         get_ids(filename_or_regex: str) -> List[str]:
             Get the relative paths of assets matching the given filename_or_regex.
 
-        download(filename_or_regex: str, overwrite=False, progress_bar: bool | None = None, timeout: float = 20.0, leave=True, chunk_size=65536) -> bool:
+        download(filename_or_regex: str, overwrite=False, progress_bar: bool = None, timeout: float = 20.0, leave=True, chunk_size=65536) -> bool:
             Download assets matching the given filename regex and save them to the appropriate file paths inside the assets root directory.
 
-        extract(filename_or_regex: str, archive_name_or_regex: str | None = None, overwrite=False, download_archive=True) -> List[str]:
+        extract(filename_or_regex: str, archive_name_or_regex: str = None, overwrite=False, download_archive=True) -> List[str]:
             extract the files matching the argument from an archived dataset into the appropriate location.
 
         fetch(filename_or_regex: str, overwrite=False, archive_name_or_regex: str=None, download_archive=False) -> List[str]:
@@ -206,7 +206,7 @@ class Assets:
     def extract(
         cls,
         filename_or_regex: str,
-        archive_name_or_regex: str | None = None,
+        archive_name_or_regex: Optional[str] = None,
         overwrite=False,
         progress_bar=True,
         leave=True,
@@ -266,7 +266,7 @@ class Assets:
         overwrite=False,
         timeout: float = 20.0,
         chunk_size=2**18,
-        progress_bar: bool | None = None,
+        progress_bar: Optional[bool] = None,
         leave=True,
     ) -> List[str]:
         """
@@ -335,7 +335,7 @@ class Assets:
         cls,
         filename_or_regex: str,
         overwrite=False,
-        archive_name_or_regex: str | None = None,
+        archive_name_or_regex: Optional[str] = None,
         download_archive=False,
         progress_bar=True,
         leave=True,

--- a/sign_language_translator/config/enums.py
+++ b/sign_language_translator/config/enums.py
@@ -18,6 +18,7 @@ Functions:
 from __future__ import annotations
 
 from enum import Enum
+from typing import Union
 
 from sign_language_translator.utils import (
     PrintableEnumMeta,
@@ -172,6 +173,7 @@ class ModelCodes(Enum, metaclass=PrintableEnumMeta):
 
     # text-embedding-models
 
+
 class ModelCodeGroups(Enum, metaclass=PrintableEnumMeta):
     """
     Enumeration class for grouping supported model codes, making it easier to filter various models.
@@ -214,8 +216,9 @@ class ModelCodeGroups(Enum, metaclass=PrintableEnumMeta):
     }
     ALL_VIDEO_EMBEDDING_MODELS = ALL_MEDIAPIPE_EMBEDDING_MODELS
 
+
 # TODO: move the mapping list outside of the function. maybe convert it to a class variable.
-def normalize_short_code(short_code: str | Enum) -> str:
+def normalize_short_code(short_code: Union[str, Enum]) -> str:
     """
     Normalize the provided short code to a standard form that is recognized package wide.
 

--- a/sign_language_translator/languages/__init__.py
+++ b/sign_language_translator/languages/__init__.py
@@ -1,11 +1,10 @@
-from sign_language_translator.languages.utils import (
-    get_text_language,
-    get_sign_language,
-)
-from sign_language_translator.languages import text, sign
-
+from sign_language_translator.languages import sign, text
 from sign_language_translator.languages.sign import SignLanguage
 from sign_language_translator.languages.text import TextLanguage
+from sign_language_translator.languages.utils import (
+    get_sign_language,
+    get_text_language,
+)
 from sign_language_translator.languages.vocab import Vocab
 
 __all__ = [

--- a/sign_language_translator/languages/sign/mapping_rules.py
+++ b/sign_language_translator/languages/sign/mapping_rules.py
@@ -37,8 +37,8 @@ class MappingRule(ABC):
     def is_applicable(
         self,
         token: str,
-        tag: Any | None = None,
-        context: Any | None = None,
+        tag: Any = None,
+        context: Any = None,
     ) -> bool:
         """
         Check if the mapping rule is applicable for the given token, tag, and context.

--- a/sign_language_translator/languages/sign/pakistan_sign_language.py
+++ b/sign_language_translator/languages/sign/pakistan_sign_language.py
@@ -2,7 +2,7 @@
 
 import random
 import re
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from sign_language_translator.config.assets import Assets
 from sign_language_translator.config.enums import SignLanguages
@@ -68,9 +68,9 @@ class PakistanSignLanguage(SignLanguage):
     def tokens_to_sign_dicts(
         self,
         tokens: Iterable[str],
-        tags: Iterable[Any] | None = None,
-        contexts: Iterable[Any] | None = None,
-    ) -> List[Dict[str, List[List[str]] | List[float]]]:
+        tags: Optional[Iterable[Any]] = None,
+        contexts: Optional[Iterable[Any]] = None,
+    ) -> List[Dict[str, Union[List[List[str]], List[float]]]]:
         # fix args
         if isinstance(tokens, str):
             tokens = [tokens]
@@ -90,7 +90,7 @@ class PakistanSignLanguage(SignLanguage):
 
     def _apply_rules(
         self, token: str, tag=None, context=None
-    ) -> List[Dict[str, List[List[str]] | List[float]]]:
+    ) -> List[Dict[str, Union[List[List[str]], List[float]]]]:
         """Applies all the mapping rules to a token.
         Rules with lower value of priority overwrite the result.
         If multiple rules of same priority are applicable, one is selected at random.
@@ -129,8 +129,8 @@ class PakistanSignLanguage(SignLanguage):
     def restructure_sentence(
         self,
         sentence: Iterable[str],
-        tags: Iterable[Any] | None = None,
-        contexts: Iterable[Any] | None = None,
+        tags: Optional[Iterable[Any]] = None,
+        contexts: Optional[Iterable[Any]] = None,
     ) -> Tuple[Iterable[str], Iterable[Any], Iterable[Any]]:
         # Fix the args
         tags = [Tags.DEFAULT for _ in sentence] if tags is None else tags
@@ -168,9 +168,9 @@ class PakistanSignLanguage(SignLanguage):
     def __call__(
         self,
         tokens: Iterable[str],
-        tags: Iterable[Any] | None = None,
-        contexts: Iterable[Any] | None = None,
-    ) -> List[Dict[str, List[List[str]] | List[float]]]:
+        tags: Optional[Iterable[Any]] = None,
+        contexts: Optional[Iterable[Any]] = None,
+    ) -> List[Dict[str, Union[List[List[str]], List[float]]]]:
         tokens, tags, contexts = self.restructure_sentence(
             tokens, tags=tags, contexts=contexts
         )

--- a/sign_language_translator/languages/sign/sign_language.py
+++ b/sign_language_translator/languages/sign/sign_language.py
@@ -2,7 +2,7 @@
 
 import enum
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from sign_language_translator.utils import PrintableEnumMeta
 
@@ -41,9 +41,9 @@ class SignLanguage(ABC):
     def tokens_to_sign_dicts(
         self,
         tokens: Iterable[str],
-        tags: Iterable[Any] | None = None,
-        contexts: Iterable[Any] | None = None,
-    ) -> List[Dict[str, List[List[str]] | List[float]]]:
+        tags: Optional[Iterable[Any]] = None,
+        contexts: Optional[Iterable[Any]] = None,
+    ) -> List[Dict[str, Union[List[List[str]], List[float]]]]:
         """Converts tokens to signs based on rules and returns a list of sign dictionaries.
 
         Args:
@@ -62,8 +62,8 @@ class SignLanguage(ABC):
     def restructure_sentence(
         self,
         sentence: Iterable[str],
-        tags: Iterable[Any] | None = None,
-        contexts: Iterable[Any] | None = None,
+        tags: Optional[Iterable[Any]] = None,
+        contexts: Optional[Iterable[Any]] = None,
     ) -> Tuple[Iterable[str], Iterable[Any], Iterable[Any]]:
         """Restructures a sentence by changing the grammar,
         removing stopwords, spaces & punctuation, and modifying token contents.
@@ -79,7 +79,7 @@ class SignLanguage(ABC):
 
     def _make_equal_weight_sign_dict(
         self, signs: List[List[str]]
-    ) -> Dict[str, List[List[str]] | List[float]]:
+    ) -> Dict[str, Union[List[List[str]], List[float]]]:
         """Creates a sign dictionary with equal weights for the provided signs.
 
         Args:

--- a/sign_language_translator/languages/text/urdu.py
+++ b/sign_language_translator/languages/text/urdu.py
@@ -347,10 +347,13 @@ class Urdu(TextLanguage):
         }
 
         # Convert the dictionaries to a useable format
-        CHARACTER_TRANSLATOR = {ord(c): w for c, w in CHARACTER_TO_WORD.items()} | {
-            ord(non_urdu): urdu
-            for urdu, others in CORRECT_URDU_CHARACTERS_TO_INCORRECT.items()
-            for non_urdu in others
+        CHARACTER_TRANSLATOR = {
+            **{ord(c): w for c, w in CHARACTER_TO_WORD.items()},
+            **{
+                ord(non_urdu): urdu
+                for urdu, others in CORRECT_URDU_CHARACTERS_TO_INCORRECT.items()
+                for non_urdu in others
+            },
         }
         COMBINE_CHARACTERS_REGEX = r"|".join(SPLIT_TO_COMBINED_CHARACTERS.keys())
         DIACRITICS_REGEX = r"|".join(DIACRITICS)

--- a/sign_language_translator/languages/utils.py
+++ b/sign_language_translator/languages/utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from sign_language_translator.config.enums import (
     SignLanguages,
@@ -18,8 +18,9 @@ if TYPE_CHECKING:
     from sign_language_translator.languages.sign import SignLanguage
     from sign_language_translator.languages.text import TextLanguage
 
+
 # TODO: AbstractFactory to store str to class mappings
-def get_text_language(language_name: str | Enum) -> TextLanguage:
+def get_text_language(language_name: Union[str, Enum]) -> TextLanguage:
     """
     Retrieves a TextLanguage object based on the provided language name.
 
@@ -46,7 +47,7 @@ def get_text_language(language_name: str | Enum) -> TextLanguage:
     raise ValueError(f"no text language class known for '{language_name = }'")
 
 
-def get_sign_language(language_name: str | Enum) -> SignLanguage:
+def get_sign_language(language_name: Union[str, Enum]) -> SignLanguage:
     """
     Retrieves a SignLanguage object based on the provided language name.
 

--- a/sign_language_translator/languages/vocab.py
+++ b/sign_language_translator/languages/vocab.py
@@ -184,7 +184,7 @@ class Vocab:
         Takes JSON word mapping datasets and creates a dictionary mapping text tokens to sign labels.
 
         Args:
-            language (str | None, optional): Language code used in JSON or a regex matching it whose data should be extracted. Defaults to None.
+            language (str, optional): Language code used in JSON or a regex matching it whose data should be extracted. Defaults to None.
             country (str): Country code used to filter the mapping datasets.
             organization (str): Organization code used to filter the mapping datasets.
             part_number (str): Part number used to filter the mapping datasets.

--- a/sign_language_translator/models/_utils.py
+++ b/sign_language_translator/models/_utils.py
@@ -13,7 +13,7 @@ __all__ = [
     "get_model",
 ]
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from sign_language_translator.config.assets import Assets
 from sign_language_translator.config.enums import (
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from enum import Enum
 
 
-def get_model(model_code: str | Enum, *args, **kwargs):
+def get_model(model_code: Union[str, Enum], *args, **kwargs):
     """
     Get the model based on the provided model code and optional parameters.
     See sign_language_translator.config.enums.ModelCodes

--- a/sign_language_translator/models/language_models/beam_sampling.py
+++ b/sign_language_translator/models/language_models/beam_sampling.py
@@ -2,7 +2,7 @@
 
 from math import exp, log2
 from random import random
-from typing import Any, Callable, Iterable, Tuple
+from typing import Any, Callable, Iterable, Optional, Tuple
 
 from sign_language_translator.models.language_models.abstract_language_model import (
     LanguageModel,
@@ -48,12 +48,12 @@ class BeamSampling:
         self.scoring_function = scoring_function
         self.return_log_of_probability = return_log_of_probability
 
-    def __call__(self, context: Iterable | None = None) -> Iterable:
+    def __call__(self, context: Optional[Iterable] = None) -> Iterable:
         return self.complete(initial_context=context)
 
     def complete(
         self,
-        initial_context: Iterable | None = None,
+        initial_context: Optional[Iterable] = None,
         append_func: Callable[[Any, Any], Any] = lambda context, token: (
             context + [token]
             if isinstance(context, list)

--- a/sign_language_translator/models/language_models/beam_sampling.py
+++ b/sign_language_translator/models/language_models/beam_sampling.py
@@ -129,6 +129,6 @@ class BeamSampling:
 
         # reformat score
         if not self.return_log_of_probability:
-            score = 2 ** score # math.exp2(score)
+            score = 2**score  # math.exp2(score)
 
         return selected_completion, score

--- a/sign_language_translator/models/language_models/mixer.py
+++ b/sign_language_translator/models/language_models/mixer.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pickle
 from os.path import exists
-from typing import Any, Iterable, List, Tuple
+from typing import Any, Iterable, List, Optional, Tuple
 
 from sign_language_translator.models.language_models.abstract_language_model import (
     LanguageModel,
@@ -41,7 +41,7 @@ class MixerLM(LanguageModel):
     def __init__(
         self,
         models: List[LanguageModel],
-        selection_probabilities: List[float] | None = None,
+        selection_probabilities: Optional[List[float]] = None,
         unknown_token="<unk>",
         name=None,
         model_selection_strategy="choose" or "merge",

--- a/sign_language_translator/models/language_models/transformer_language_model/model.py
+++ b/sign_language_translator/models/language_models/transformer_language_model/model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from os.path import exists
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -68,9 +68,9 @@ class TransformerLanguageModel(LanguageModel, torch.nn.Module):
         activation="gelu",
         device="cuda" if torch.cuda.is_available() else "cpu",
         sampling_temperature: float = 1.0,
-        top_k: int | None = None,
-        top_p: float | None = 0.9,
-        name: str | None = None,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = 0.9,
+        name: Optional[str] = None,
         pretrained_token_embeddings: torch.Tensor | None = None,
         randomly_shift_position_embedding_during_training: bool = False,
     ) -> None:

--- a/sign_language_translator/models/language_models/transformer_language_model/model.py
+++ b/sign_language_translator/models/language_models/transformer_language_model/model.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from os.path import exists
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -71,7 +71,7 @@ class TransformerLanguageModel(LanguageModel, torch.nn.Module):
         top_k: Optional[int] = None,
         top_p: Optional[float] = 0.9,
         name: Optional[str] = None,
-        pretrained_token_embeddings: torch.Tensor | None = None,
+        pretrained_token_embeddings: Optional[torch.Tensor] = None,
         randomly_shift_position_embedding_during_training: bool = False,
     ) -> None:
         """Transformer-based language model for text generation.
@@ -363,7 +363,7 @@ class TransformerLanguageModel(LanguageModel, torch.nn.Module):
 
         return [self.token_to_id.get(token, self.unknown_token_id) for token in tokens]
 
-    def ids_to_tokens(self, ids: Iterable[int] | torch.Tensor):
+    def ids_to_tokens(self, ids: Union[Iterable[int], torch.Tensor]):
         """
         Convert a sequence of token IDs to tokens.
 

--- a/sign_language_translator/models/language_models/transformer_language_model/train.py
+++ b/sign_language_translator/models/language_models/transformer_language_model/train.py
@@ -107,9 +107,11 @@ class LM_Trainer:
         lr_update_step_count: Optional[int] = None,
         optimizer="adamw",
         seed: int = 0,
-        model_output_renderer: Callable[[TransformerLanguageModel], str] | None = None,
-        epoch_unfreeze_map: Dict[int, List[str]] | None = None,
-        class_weights: torch.Tensor | None = None,
+        model_output_renderer: Optional[
+            Callable[[TransformerLanguageModel], str]
+        ] = None,
+        epoch_unfreeze_map: Optional[Dict[int, List[str]]] = None,
+        class_weights: Optional[torch.Tensor] = None,
         max_gradient_norm: Optional[float] = None,
     ):
         self.model = model.to(device)

--- a/sign_language_translator/models/language_models/transformer_language_model/train.py
+++ b/sign_language_translator/models/language_models/transformer_language_model/train.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 from glob import glob
 from time import time
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -104,13 +104,13 @@ class LM_Trainer:
         lr_lambda: Callable[
             [int, float, float], float
         ] = lambda epoch, base_lr, last_lr: base_lr,
-        lr_update_step_count: int | None = None,
+        lr_update_step_count: Optional[int] = None,
         optimizer="adamw",
         seed: int = 0,
         model_output_renderer: Callable[[TransformerLanguageModel], str] | None = None,
         epoch_unfreeze_map: Dict[int, List[str]] | None = None,
         class_weights: torch.Tensor | None = None,
-        max_gradient_norm: float | None = None,
+        max_gradient_norm: Optional[float] = None,
     ):
         self.model = model.to(device)
         self.device = device

--- a/sign_language_translator/models/text_to_sign/concatenative_synthesis.py
+++ b/sign_language_translator/models/text_to_sign/concatenative_synthesis.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 from enum import Enum
-from typing import List, Type
+from typing import List, Type, Union
 
 from sign_language_translator.config.enums import SignFormats
 from sign_language_translator.languages import get_sign_language, get_text_language
@@ -22,9 +22,9 @@ class ConcatenativeSynthesis(TextToSignModel):
 
     def __init__(
         self,
-        text_language: str | TextLanguage | Enum,
-        sign_language: str | SignLanguage | Enum,
-        sign_format: str | Type[Sign],
+        text_language: Union[str, TextLanguage, Enum],
+        sign_language: Union[str, SignLanguage, Enum],
+        sign_format: Union[str, Type[Sign]],
     ) -> None:
         """
         Args:
@@ -42,7 +42,7 @@ class ConcatenativeSynthesis(TextToSignModel):
         return self._text_language
 
     @text_language.setter
-    def text_language(self, text_language: str | TextLanguage | Enum):
+    def text_language(self, text_language: Union[str, TextLanguage, Enum]):
         self._text_language = self.__get_text_language_object(text_language)
 
     @property
@@ -51,7 +51,7 @@ class ConcatenativeSynthesis(TextToSignModel):
         return self._sign_language
 
     @sign_language.setter
-    def sign_language(self, sign_language: str | SignLanguage | Enum):
+    def sign_language(self, sign_language: Union[str, SignLanguage, Enum]):
         self._sign_language = self.__get_sign_language_object(sign_language)
 
     @property
@@ -65,7 +65,7 @@ class ConcatenativeSynthesis(TextToSignModel):
         return self._sign_format
 
     @sign_format.setter
-    def sign_format(self, sign_format: str | Type[Sign]):
+    def sign_format(self, sign_format: Union[str, Type[Sign]]):
         self._sign_format = self.__get_sign_format_class(sign_format)
 
     def translate(self, text: str, *args, **kwargs) -> Sign:
@@ -135,7 +135,7 @@ class ConcatenativeSynthesis(TextToSignModel):
         return name
 
     def __get_text_language_object(
-        self, text_language: str | TextLanguage | Enum
+        self, text_language: Union[str, TextLanguage, Enum]
     ) -> TextLanguage:
         if isinstance(text_language, (str, Enum)):
             return get_text_language(text_language)
@@ -144,7 +144,7 @@ class ConcatenativeSynthesis(TextToSignModel):
         raise TypeError(f"Expected str or TextLanguage, got {type(text_language) = }.")
 
     def __get_sign_language_object(
-        self, sign_language: str | SignLanguage | Enum
+        self, sign_language: Union[str, SignLanguage, Enum]
     ) -> SignLanguage:
         if isinstance(sign_language, (str, Enum)):
             return get_sign_language(sign_language)
@@ -152,8 +152,10 @@ class ConcatenativeSynthesis(TextToSignModel):
             return sign_language
         raise TypeError(f"Expected str or SignLanguage, got {type(sign_language) = }.")
 
-    def __get_sign_format_class(self, sign_format: str | Type[Sign]) -> Type[Sign]:
-        if isinstance(sign_format, str | Enum):
+    def __get_sign_format_class(
+        self, sign_format: Union[str, Type[Sign]]
+    ) -> Type[Sign]:
+        if isinstance(sign_format, (str, Enum)):
             return get_sign_wrapper_class(sign_format)
         if isinstance(sign_format, type) and issubclass(sign_format, Sign):
             return sign_format

--- a/sign_language_translator/models/text_to_sign/t2s_model.py
+++ b/sign_language_translator/models/text_to_sign/t2s_model.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Union
+from typing import Iterable, Union
+
+from sign_language_translator.vision.sign.sign import Sign
 
 
 class TextToSignModel(ABC):
@@ -19,8 +21,8 @@ class TextToSignModel(ABC):
         """The format of the sign language (e.g. slt.Vision.sign.sign.Sign)."""
 
     @abstractmethod
-    def translate(self, text: Union[str, Iterable[str]], *args, **kwargs) -> Any:  # -> VideoFeatures
+    def translate(self, text: Union[str, Iterable[str]], *args, **kwargs) -> Sign:
         """Translate the text to sign language."""
 
-    def __call__(self, text: Union[str, Iterable[str]], *args, **kwargs) -> Any:
+    def __call__(self, text: Union[str, Iterable[str]], *args, **kwargs) -> Sign:
         return self.translate(text, *args, **kwargs)

--- a/sign_language_translator/models/utils.py
+++ b/sign_language_translator/models/utils.py
@@ -42,7 +42,7 @@ from functools import partial
 from glob import glob
 from os import makedirs
 from os.path import abspath, basename, exists, join
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Type
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Type
 from warnings import warn
 
 import numpy
@@ -58,8 +58,8 @@ if TYPE_CHECKING:
 
 def top_p_top_k_indexes(
     probabilities: Iterable[float],
-    top_p: float | None = None,
-    top_k: int | None = None,
+    top_p: Optional[float] = None,
+    top_k: Optional[int] = None,
 ) -> List[int]:
     """Perform top-p (nucleus) and top-k filtering based on the given probabilities.
     Top-k returns the indices of the top-k elements.
@@ -183,7 +183,7 @@ def plot_lr_scheduler(
     n_steps: int = 20,
     parameter_group_number: int = 0,
     save_fig: bool = False,
-    fig_name: str | None = None,
+    fig_name: Optional[str] = None,
     **kwargs,
 ):
     """Plot the learning rate of a specific parameter group across training steps.

--- a/sign_language_translator/models/utils.py
+++ b/sign_language_translator/models/utils.py
@@ -42,7 +42,7 @@ from functools import partial
 from glob import glob
 from os import makedirs
 from os.path import abspath, basename, exists, join
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Type
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Type, Union
 from warnings import warn
 
 import numpy
@@ -176,9 +176,9 @@ class FullyLambdaLR(torch.optim.lr_scheduler.LRScheduler):
 
 def plot_lr_scheduler(
     *args,
-    lr_scheduler_class: Type[torch.optim.lr_scheduler.LRScheduler] | None = None,
-    # lr_lambda: Callable[[Any], float] | None = None,
-    lr_scheduler_object: torch.optim.lr_scheduler.LRScheduler | None = None,
+    lr_scheduler_class: Optional[Type[torch.optim.lr_scheduler.LRScheduler]] = None,
+    # lr_lambda: Optional[Callable[[Any], float]] = None,
+    lr_scheduler_object: Optional[torch.optim.lr_scheduler.LRScheduler] = None,
     initial_lr: float = 1e-3,
     n_steps: int = 20,
     parameter_group_number: int = 0,
@@ -303,8 +303,8 @@ def downwards_wave(
 
 def set_layers_trainability_(
     model: torch.nn.Module,
-    layers_to_unfreeze: List[str] | None = None,
-    layers_to_freeze: List[str] | None = None,
+    layers_to_unfreeze: Optional[List[str]] = None,
+    layers_to_freeze: Optional[List[str]] = None,
 ):
     """
     Set the trainability of specified layers in the given PyTorch model.
@@ -489,7 +489,7 @@ class VideoEmbeddingPipeline:
 
     def __save_embedding(
         self,
-        embedding: NDArray | torch.Tensor,
+        embedding: Union[NDArray, torch.Tensor],
         filename: str,
         output_dir=".",
         file_format="csv",

--- a/sign_language_translator/models/video_embedding/mediapipe_landmarks_model.py
+++ b/sign_language_translator/models/video_embedding/mediapipe_landmarks_model.py
@@ -103,11 +103,12 @@ class MediaPipeLandmarksModel(VideoEmbeddingModel):
 
         embeddings = []
 
-        with (
-            # TODO: create here or in __init__ ??
-            self._pose_class.create_from_options(self._pose_options) as pose_landmarker,
-            self._hand_class.create_from_options(self._hand_options) as hand_landmarker,
-        ):
+        # TODO: create here or in __init__ ??
+        with self._pose_class.create_from_options(
+            self._pose_options
+        ) as pose_landmarker, self._hand_class.create_from_options(
+            self._hand_options
+        ) as hand_landmarker:
             for i, frame in enumerate(frame_sequence):
                 # convert frame to mediapipe image
                 mp_image = mediapipe.Image(

--- a/sign_language_translator/models/video_embedding/mediapipe_landmarks_model.py
+++ b/sign_language_translator/models/video_embedding/mediapipe_landmarks_model.py
@@ -20,7 +20,7 @@ Example:
 """
 
 from os.path import join
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional, Union
 
 import mediapipe
 import numpy as np
@@ -78,10 +78,10 @@ class MediaPipeLandmarksModel(VideoEmbeddingModel):
 
     def embed(
         self,
-        frame_sequence: Iterable[torch.Tensor | NDArray[np.uint8]],
+        frame_sequence: Iterable[Union[torch.Tensor, NDArray[np.uint8]]],
         landmark_type: str = "world" or "image" or "all",
-        progress_callback: None | ProgressStatusCallback = None,
-        total_frames: None | int = None,
+        progress_callback: Optional[ProgressStatusCallback] = None,
+        total_frames: Optional[int] = None,
         **kwargs,
     ) -> torch.Tensor:
         """

--- a/sign_language_translator/text/synonyms.py
+++ b/sign_language_translator/text/synonyms.py
@@ -100,7 +100,7 @@ class SynonymFinder:
         text: str,
         intermediate_languages: Optional[List[str]] = None,
         time_delay: float = 1e-2,
-        timeout: float | None = 10,
+        timeout: Optional[float] = 10,
         max_n_threads: int = 132,
         lower_case: bool = True,
         progress_bar: bool = True,

--- a/sign_language_translator/text/tokenizer.py
+++ b/sign_language_translator/text/tokenizer.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 from sign_language_translator.text.utils import ListRegex
 
@@ -12,7 +12,7 @@ class SignTokenizer:
         end_of_sentence_tokens: Iterable[str] = (".", "?", "!"),
         full_stops=(".",),
         non_sentence_end_words: Iterable[str] = ("A", "B", "C"),
-        tokenized_word_sense_pattern: List | None = None,
+        tokenized_word_sense_pattern: Optional[List] = None,
     ):
         self.word_regex = word_regex
 

--- a/sign_language_translator/text/utils.py
+++ b/sign_language_translator/text/utils.py
@@ -14,7 +14,7 @@ Classes:
 """
 
 import re
-from typing import Any, Iterable, List, Set, Tuple
+from typing import Any, Iterable, List, Optional, Set, Tuple, Union
 
 
 def make_ngrams(sequence: Iterable, n: int) -> List[Iterable]:
@@ -196,8 +196,8 @@ class ListRegex:
 
     @staticmethod
     def match(
-        items: List[str], patterns: List[str | List | Tuple]
-    ) -> Tuple[int, int] | None:
+        items: List[str], patterns: List[Union[str, List, Tuple]]
+    ) -> Optional[Tuple[int, int]]:
         """
         Matches the given patterns against the items in the list.
         Applies the patterns at the start of the list of string.
@@ -282,7 +282,7 @@ class ListRegex:
         return does_match
 
     @staticmethod
-    def search(items: List[str], patterns) -> Tuple[int, int] | None:
+    def search(items: List[str], patterns) -> Optional[Tuple[int, int]]:
         """
         Searches for the first occurrence of the patterns in the list of items.
 

--- a/sign_language_translator/utils/archive.py
+++ b/sign_language_translator/utils/archive.py
@@ -10,7 +10,7 @@ import re
 import zipfile
 from glob import glob
 from os.path import basename, exists, join
-from typing import List, Optional
+from typing import List, Optional, Union
 from warnings import warn
 
 from tqdm.auto import tqdm
@@ -56,7 +56,7 @@ class Archive:
 
     @staticmethod
     def create(
-        filename_or_patterns: str | List[str],
+        filename_or_patterns: Union[str, List[str]],
         archive_path: str,
         compression=zipfile.ZIP_DEFLATED,
         progress_bar=True,
@@ -97,7 +97,7 @@ class Archive:
 
     @staticmethod
     def list(
-        archive_path: str, pattern: str = "*", regex: str | re.Pattern = r".*"
+        archive_path: str, pattern: str = "*", regex: Union[str, re.Pattern] = r".*"
     ) -> List[str]:
         """
         List files in the zip archive filtered by the specified pattern or regex.
@@ -132,7 +132,7 @@ class Archive:
     def extract(
         archive_path: str,
         pattern: str = "*",
-        regex: str | re.Pattern = r".*",
+        regex: Union[str, re.Pattern] = r".*",
         output_dir: str = ".",
         overwrite=False,
         progress_bar=True,

--- a/sign_language_translator/utils/archive.py
+++ b/sign_language_translator/utils/archive.py
@@ -10,7 +10,7 @@ import re
 import zipfile
 from glob import glob
 from os.path import basename, exists, join
-from typing import List
+from typing import List, Optional
 from warnings import warn
 
 from tqdm.auto import tqdm
@@ -30,7 +30,7 @@ class Archive:
         List the files in a ZIP archive, optionally filtered by a glob pattern or regex.
 
     - extract(archive_path: str, pattern: str = "*", regex: str | re.Pattern = r".*", output_dir: str = ".",
-              overwrite=False, progress_bar=True, leave=True, password: bytes | None = None, verbose=True) -> List[str]
+              overwrite=False, progress_bar=True, leave=True, password: bytes = None, verbose=True) -> List[str]
         Extract files from a ZIP archive to the specified output directory, optionally
         filtered by file names, patterns, or regex.
 
@@ -137,7 +137,7 @@ class Archive:
         overwrite=False,
         progress_bar=True,
         leave=True,
-        password: bytes | None = None,
+        password: Optional[bytes] = None,
         verbose=True,
     ) -> List[str]:
         """

--- a/sign_language_translator/utils/arrays.py
+++ b/sign_language_translator/utils/arrays.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Sequence, Type
+from typing import Iterable, List, Optional, Sequence, Type, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -13,7 +13,7 @@ __all__ = [
 
 class ArrayOps:
     @staticmethod
-    def floor(array: NDArray | Tensor) -> NDArray | Tensor:
+    def floor(array: Union[NDArray, Tensor]) -> Union[NDArray, Tensor]:
         if isinstance(array, np.ndarray):
             return np.floor(array)
         elif isinstance(array, Tensor):
@@ -22,7 +22,7 @@ class ArrayOps:
             raise TypeError(f"Invalid type for flooring: {type(array)}")
 
     @staticmethod
-    def ceil(array: NDArray | Tensor) -> NDArray | Tensor:
+    def ceil(array: Union[NDArray, Tensor]) -> Union[NDArray, Tensor]:
         if isinstance(array, np.ndarray):
             return np.ceil(array)
         elif isinstance(array, Tensor):
@@ -32,8 +32,8 @@ class ArrayOps:
 
     @staticmethod
     def take(
-        array: NDArray | Tensor, index: NDArray | Tensor | List, dim: int = 0
-    ) -> NDArray | Tensor:
+        array: Union[NDArray, Tensor], index: Union[NDArray, Tensor, List], dim: int = 0
+    ) -> Union[NDArray, Tensor]:
         if isinstance(array, np.ndarray):
             if not isinstance(index, np.ndarray):
                 index = np.array(index)
@@ -47,8 +47,9 @@ class ArrayOps:
 
     @staticmethod
     def cast(
-        x: NDArray | Tensor | List | Iterable, data_type: Type[np.ndarray | Tensor]
-    ) -> NDArray | Tensor:
+        x: Union[NDArray, Tensor, List, Iterable],
+        data_type: Type[Union[np.ndarray, Tensor]],
+    ) -> Union[NDArray, Tensor]:
         if data_type == np.ndarray:
             return np.array(x)
         elif data_type == Tensor:
@@ -58,12 +59,12 @@ class ArrayOps:
 
 
 def linear_interpolation(
-    array: NDArray[np.float64] | Tensor | List,
-    new_indexes: Sequence[int | float] | None = None,
-    old_x: Sequence[int | float] | None = None,
-    new_x: Sequence[int | float] | None = None,
+    array: Union[NDArray[np.float64], Tensor, List],
+    new_indexes: Optional[Sequence[Union[int, float]]] = None,
+    old_x: Optional[Sequence[Union[int, float]]] = None,
+    new_x: Optional[Sequence[Union[int, float]]] = None,
     dim: int = 0,
-) -> NDArray | Tensor:
+) -> Union[NDArray, Tensor]:
     """
     Perform linear interpolation on a multidimensional array or tensor along a dimension.
 

--- a/sign_language_translator/utils/parallel.py
+++ b/sign_language_translator/utils/parallel.py
@@ -8,7 +8,7 @@ Functions:
 
 import threading
 from time import sleep
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Optional
 
 from tqdm.auto import tqdm
 
@@ -17,7 +17,7 @@ def threaded_map(
     target: Callable,
     args_list: Iterable,
     time_delay=0.02,
-    timeout: float | None = None,
+    timeout: Optional[float] = None,
     max_n_threads=None,
     progress_bar=True,
     leave=True,

--- a/sign_language_translator/utils/utils.py
+++ b/sign_language_translator/utils/utils.py
@@ -1,7 +1,7 @@
 import re
 from enum import EnumMeta
 from random import choices
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Set, Union
 
 from tqdm.auto import tqdm
 
@@ -188,7 +188,7 @@ class ProgressStatusCallback:
         self.tqdm_bar.set_postfix(status, refresh=True)
 
 
-def is_regex(string: str | re.Pattern) -> bool:
+def is_regex(string: Union[str, re.Pattern]) -> bool:
     """Tests whether the argument is a regex or a regular string.
 
     Args:
@@ -206,3 +206,5 @@ def is_regex(string: str | re.Pattern) -> bool:
             return True
         except re.error:
             return False
+
+    return False

--- a/sign_language_translator/vision/utils.py
+++ b/sign_language_translator/vision/utils.py
@@ -2,7 +2,7 @@
 """
 
 from mimetypes import guess_type
-from typing import Generator, List, Sequence, Tuple
+from typing import Generator, List, Optional, Sequence, Tuple
 
 import cv2
 from numpy import uint8
@@ -72,7 +72,7 @@ def iter_frames_with_opencv(path: str) -> Generator[NDArray[uint8], None, None]:
 
 
 def _normalize_args_index_and_timestamp(
-    timestamp: float | None, index: int | None, max_duration: float, max_index: int
+    timestamp: Optional[float], index: Optional[int], max_duration: float, max_index: int
 ) -> Tuple[float, int]:
     if (timestamp is not None) and index is None:
         if not 0 <= timestamp <= max_duration:

--- a/sign_language_translator/vision/utils.py
+++ b/sign_language_translator/vision/utils.py
@@ -2,7 +2,7 @@
 """
 
 from mimetypes import guess_type
-from typing import Generator, List, Optional, Sequence, Tuple
+from typing import Generator, List, Optional, Sequence, Tuple, Union
 
 import cv2
 from numpy import uint8
@@ -72,7 +72,10 @@ def iter_frames_with_opencv(path: str) -> Generator[NDArray[uint8], None, None]:
 
 
 def _normalize_args_index_and_timestamp(
-    timestamp: Optional[float], index: Optional[int], max_duration: float, max_index: int
+    timestamp: Optional[float],
+    index: Optional[int],
+    max_duration: float,
+    max_index: int,
 ) -> Tuple[float, int]:
     if (timestamp is not None) and index is None:
         if not 0 <= timestamp <= max_duration:
@@ -97,7 +100,7 @@ def _normalize_args_index_and_timestamp(
 
 
 def _validate_and_normalize_slices(
-    keys: int | slice | Sequence[int | slice], max_n_dims: int = 4
+    keys: Union[int, slice, Sequence[Union[int, slice]]], max_n_dims: int = 4
 ) -> Tuple[slice, ...]:
     if not isinstance(keys, Sequence):
         keys = [keys]

--- a/sign_language_translator/vision/video/video.py
+++ b/sign_language_translator/vision/video/video.py
@@ -9,7 +9,7 @@ from copy import copy, deepcopy
 from mimetypes import guess_type
 from os import makedirs
 from os.path import abspath, dirname, isfile, join
-from typing import Callable, Generator, Iterable, List, Sequence, Tuple
+from typing import Callable, Generator, Iterable, List, Optional, Sequence, Tuple
 
 import cv2  # TODO: Compile OpenCV with GPU
 import numpy as np
@@ -44,12 +44,12 @@ class Video(Sign, VideoFrames):
         | Generator[NDArray[np.uint8], None, None],
         **kwargs,
     ) -> None:
-        self._path: str | None = None
+        self._path: Optional[str] = None
 
         # ToDo: use list of sources instead of linked list of videos.
         # source
         self.source: VideoFrames
-        self.__next: Video | None = None
+        self.__next: Optional[Video] = None
 
         # play
         self._source_start_index: int = 0
@@ -82,7 +82,7 @@ class Video(Sign, VideoFrames):
     # ========================= #
 
     def get_frame(
-        self, timestamp: float | None = None, index: int | None = None
+        self, timestamp: Optional[float] = None, index: Optional[int] = None
     ) -> NDArray[np.uint8]:
         # allow negative indexing
         if index and index < 0:
@@ -114,10 +114,10 @@ class Video(Sign, VideoFrames):
 
     def trim(
         self,
-        start_time: float | None = None,
-        end_time: float | None = None,
-        start_index: int | None = None,
-        end_index: int | None = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        start_index: Optional[int] = None,
+        end_index: Optional[int] = None,
     ) -> Video:
         # allow negative indexing
         if start_index and start_index < 0:
@@ -162,7 +162,7 @@ class Video(Sign, VideoFrames):
         return new
 
     def iter_frames(
-        self, start: int = 0, end: int | None = None, step: int | None = None
+        self, start: int = 0, end: Optional[int] = None, step: Optional[int] = None
     ):
         for i in range(start, end or len(self), (step or 1) * self._default_step_size):
             yield self.get_frame(index=i)
@@ -298,7 +298,7 @@ class Video(Sign, VideoFrames):
             )
 
     def show_frame(
-        self, timestamp: float | None = None, index: int | None = None
+        self, timestamp: Optional[float] = None, index: Optional[int] = None
     ) -> None:
         frame = self.get_frame(timestamp=timestamp, index=index)
 
@@ -306,7 +306,7 @@ class Video(Sign, VideoFrames):
             VideoDisplay.display_frames([frame], inline_player="jshtml")
 
     def frames_grid(
-        self, rows=2, columns=3, width: int | None = None, height: int | None = None
+        self, rows=2, columns=3, width: Optional[int] = None, height: Optional[int] = None
     ):
         grid = np.concatenate(
             [
@@ -333,7 +333,7 @@ class Video(Sign, VideoFrames):
         return grid
 
     def show_frames_grid(
-        self, rows=2, columns=3, width: int | None = 800, height: int | None = None
+        self, rows=2, columns=3, width: Optional[int] = 800, height: Optional[int] = None
     ):
         grid = self.frames_grid(rows=rows, columns=columns, width=width, height=height)
 
@@ -508,13 +508,13 @@ class Video(Sign, VideoFrames):
         frames_iterable: Iterable[NDArray[np.uint8]],
         path: str,
         overwrite=False,
-        height: int | None = None,
-        width: int | None = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
         fps: float = 30.0,
         codec: str = "XVID",
         progress_bar=True,
         leave=False,
-        total_frames: int | None = None,
+        total_frames: Optional[int] = None,
         **kwargs,
     ) -> None:
         path = abspath(path)
@@ -554,8 +554,8 @@ class Video(Sign, VideoFrames):
         self,
         path: str,
         overwrite=False,
-        fps: float | None = None,
-        codec: str | None = None,
+        fps: Optional[float] = None,
+        codec: Optional[str] = None,
         progress_bar=True,
         leave=False,
         **kwargs,
@@ -586,8 +586,8 @@ class Video(Sign, VideoFrames):
     def save_frame(
         self,
         path: str,
-        timestamp: float | None = None,
-        index: int | None = None,
+        timestamp: Optional[float] = None,
+        index: Optional[int] = None,
         overwrite=False,
     ) -> None:
         """
@@ -618,8 +618,8 @@ class Video(Sign, VideoFrames):
         path: str,
         rows: int = 2,
         columns: int = 3,
-        width: int | None = 1024,
-        height: int | None = None,
+        width: Optional[int] = 1024,
+        height: Optional[int] = None,
         overwrite=False,
     ) -> None:
         path = abspath(path)

--- a/sign_language_translator/vision/video/video.py
+++ b/sign_language_translator/vision/video/video.py
@@ -9,7 +9,7 @@ from copy import copy, deepcopy
 from mimetypes import guess_type
 from os import makedirs
 from os.path import abspath, dirname, isfile, join
-from typing import Callable, Generator, Iterable, List, Optional, Sequence, Tuple
+from typing import Callable, Generator, Iterable, List, Optional, Sequence, Tuple, Union
 
 import cv2  # TODO: Compile OpenCV with GPU
 import numpy as np
@@ -37,11 +37,13 @@ from sign_language_translator.vision.video.video_iterators import (
 class Video(Sign, VideoFrames):
     def __init__(
         self,
-        sign: str
-        | Sequence[NDArray[np.uint8] | torch.Tensor]
-        | NDArray[np.uint8]
-        | torch.Tensor
-        | Generator[NDArray[np.uint8], None, None],
+        sign: Union[
+            str,
+            Sequence[Union[NDArray[np.uint8], torch.Tensor]],
+            NDArray[np.uint8],
+            torch.Tensor,
+            Generator[NDArray[np.uint8], None, None],
+        ],
         **kwargs,
     ) -> None:
         self._path: Optional[str] = None
@@ -167,7 +169,7 @@ class Video(Sign, VideoFrames):
         for i in range(start, end or len(self), (step or 1) * self._default_step_size):
             yield self.get_frame(index=i)
 
-    def __get_node(self, index: int) -> Tuple[Video | None, int]:
+    def __get_node(self, index: int) -> Tuple[Optional[Video], int]:
         """
         Find the node in the video linked list that contains the specified index/frame.
 
@@ -205,8 +207,8 @@ class Video(Sign, VideoFrames):
         raise StopIteration
 
     def __getitem__(
-        self, key: int | slice | Sequence[int | slice]
-    ) -> Video | NDArray[np.uint8]:
+        self, key: Union[int, slice, Sequence[Union[int, slice]]]
+    ) -> Union[Video, NDArray[np.uint8]]:
         slices = _validate_and_normalize_slices(key, max_n_dims=4)
         if len(slices) > 4:
             raise ValueError(f"Expected at most 4 slices. Got {len(slices)}: {key}")
@@ -306,7 +308,11 @@ class Video(Sign, VideoFrames):
             VideoDisplay.display_frames([frame], inline_player="jshtml")
 
     def frames_grid(
-        self, rows=2, columns=3, width: Optional[int] = None, height: Optional[int] = None
+        self,
+        rows=2,
+        columns=3,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
     ):
         grid = np.concatenate(
             [
@@ -333,7 +339,11 @@ class Video(Sign, VideoFrames):
         return grid
 
     def show_frames_grid(
-        self, rows=2, columns=3, width: Optional[int] = 800, height: Optional[int] = None
+        self,
+        rows=2,
+        columns=3,
+        width: Optional[int] = 800,
+        height: Optional[int] = None,
     ):
         grid = self.frames_grid(rows=rows, columns=columns, width=width, height=height)
 

--- a/sign_language_translator/vision/video/video_iterators.py
+++ b/sign_language_translator/vision/video/video_iterators.py
@@ -256,7 +256,7 @@ class VideoCaptureFrames(VideoFrames):
         if new_read_time is not None:
             self._read_time = self._read_time * 0.95 + 0.05 * new_read_time
 
-    def read_frame(self) -> NDArray[np.uint8] | None:
+    def read_frame(self) -> Optional[NDArray[np.uint8]]:
         """
         Read the next frame from the video.
 
@@ -551,7 +551,7 @@ class VideoSource(VideoFrames):
         start_index: int = 0,
         end_index: Optional[int] = None,
         step_size: int = 1,
-        transformations: List[Callable] | None = None,
+        transformations: Optional[List[Callable]] = None,
     ) -> None:
         self.source = source
         if start_index < 0 or start_index >= len(self.source):

--- a/sign_language_translator/vision/video/video_iterators.py
+++ b/sign_language_translator/vision/video/video_iterators.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from os.path import abspath
 from time import time
-from typing import Iterable, Sequence
+from typing import Iterable, Optional, Sequence
 
 import cv2
 import numpy as np
@@ -34,7 +34,7 @@ class VideoFrames(ABC):
     releasing resources, and providing information about the video.
 
     Methods:
-    - get_frame(timestamp: float | None = None, index: int | None = None) -> NDArray[np.uint8]:
+    - get_frame(timestamp: float = None, index: int = None) -> NDArray[np.uint8]:
         Get a frame at a given timestamp or index from the video object.
 
     - close():
@@ -56,7 +56,7 @@ class VideoFrames(ABC):
 
     @abstractmethod
     def get_frame(
-        self, timestamp: float | None = None, index: int | None = None
+        self, timestamp: Optional[float] = None, index: Optional[int] = None
     ) -> NDArray[np.uint8]:
         """Get a frame at a given timestamp or index from the video object."""
 
@@ -112,13 +112,13 @@ class VideoCaptureFrames(VideoFrames):
         _n_channels (int): Number of color channels in the video frames.
 
     Methods:
-        get_frame(timestamp: float | None = None, index: int | None = None) -> NDArray[np.uint8]:
+        get_frame(timestamp: float = None, index: int = None) -> NDArray[np.uint8]:
             Retrieve a video frame based on either a timestamp or an index.
 
         current_index() -> int:
             Get the current index of the video frame being read.
 
-        seek(timestamp: float | None = None, index: int | None = None):
+        seek(timestamp: float = None, index: int = None):
             Move the video frame position to the specified timestamp or index.
 
         read_frame() -> NDArray[np.uint8] | None:
@@ -164,8 +164,8 @@ class VideoCaptureFrames(VideoFrames):
 
     def get_frame(
         self,
-        timestamp: float | None = None,
-        index: int | None = None,
+        timestamp: Optional[float] = None,
+        index: Optional[int] = None,
     ) -> NDArray[np.uint8]:
         """
         Retrieve a video frame at a specified timestamp or index.
@@ -215,7 +215,7 @@ class VideoCaptureFrames(VideoFrames):
         """Where the VideoCapture is currently pointing to."""
         return int(self.video_capture.get(cv2.CAP_PROP_POS_FRAMES))
 
-    def seek(self, timestamp: float | None = None, index: int | None = None):
+    def seek(self, timestamp: Optional[float] = None, index: Optional[int] = None):
         """
         Seek to a specified timestamp or frame index.
 
@@ -355,7 +355,7 @@ class SequenceFrames(VideoFrames):
         self._n_channels = frame_shape[2] if len(frame_shape) == 3 else 1
 
     def get_frame(
-        self, timestamp: float | None = None, index: int | None = None
+        self, timestamp: Optional[float] = None, index: Optional[int] = None
     ) -> NDArray[np.uint8]:
         """
         Retrieve a video frame based on the specified timestamp or index.
@@ -430,7 +430,7 @@ class IterableFrames(VideoFrames):
         total_frames (int): The total number of frames in the video.
 
     Methods:
-        get_frame(timestamp: float | None = None, index: int | None = None) -> NDArray[np.uint8]:
+        get_frame(timestamp: float = None, index: int = None) -> NDArray[np.uint8]:
             Retrieve a video frame by specifying either a timestamp or an index.
 
         close():
@@ -461,7 +461,7 @@ class IterableFrames(VideoFrames):
         self._n_channels = frame.shape[2] if len(frame.shape) == 3 else 1
 
     def get_frame(
-        self, timestamp: float | None = None, index: int | None = None
+        self, timestamp: Optional[float] = None, index: Optional[int] = None
     ) -> NDArray[np.uint8]:
         """
         Retrieve a video frame by specifying either a timestamp or an index.
@@ -549,7 +549,7 @@ class VideoSource(VideoFrames):
         self,
         source: VideoFrames,
         start_index: int = 0,
-        end_index: int | None = None,
+        end_index: Optional[int] = None,
         step_size: int = 1,
         transformations: List[Callable] | None = None,
     ) -> None:
@@ -606,7 +606,7 @@ class VideoSource(VideoFrames):
         )
 
     def get_frame(
-        self, timestamp: float | None = None, index: int | None = None
+        self, timestamp: Optional[float] = None, index: Optional[int] = None
     ) -> NDArray[np.uint8]:
         timestamp, index = _normalize_args_index_and_timestamp(
             timestamp,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,17 +98,14 @@ def test_slt_assets_download():
 def test_slt_assets_tree():
     runner = CliRunner()
 
-    result = runner.invoke(
-        slt, ["assets", "tree"]
-    )
+    result = runner.invoke(slt, ["assets", "tree"])
     assert result.exit_code == 0
     assert result.output.strip().startswith("assets")
+
 
 def test_slt_assets_path():
     runner = CliRunner()
 
-    result = runner.invoke(
-        slt, ["assets", "path"]
-    )
+    result = runner.invoke(slt, ["assets", "path"])
     assert result.exit_code == 0
     assert result.output.strip() == Assets.ROOT_DIR

--- a/tests/test_config/test_assets.py
+++ b/tests/test_config/test_assets.py
@@ -30,7 +30,7 @@ def test_set_assets_dir():
 
 def test_resource_urls_are_live():
     # load the full list of URLs
-    Assets.load_all_urls()
+    # Assets.load_all_urls()
 
     # send requests
     def get_url_status(name_url_tuple, storage):

--- a/tests/test_config/test_assets.py
+++ b/tests/test_config/test_assets.py
@@ -30,7 +30,7 @@ def test_set_assets_dir():
 
 def test_resource_urls_are_live():
     # load the full list of URLs
-    # Assets.load_all_urls()
+    Assets.load_all_urls()  # comment it out to save time
 
     # send requests
     def get_url_status(name_url_tuple, storage):

--- a/tests/test_models/test_language_models/test_ngram_language_model.py
+++ b/tests/test_models/test_language_models/test_ngram_language_model.py
@@ -1,3 +1,4 @@
+import os
 import random
 from re import match
 
@@ -44,3 +45,10 @@ def test_ngram_language_model():
     generation, prob = sampler.complete("x")
     assert generation == "x"  # unknown token is not appended
     assert prob == 1  # 2**0
+
+    # save model
+    os.makedirs("temp", exist_ok=True)
+    lm1.save("temp/lm1.json", overwrite=True)
+
+    assert os.path.exists("temp/lm1.json")
+    assert NgramLanguageModel.load("temp/lm1.json").model == lm1.model

--- a/tests/test_models/test_language_models/test_ngram_language_model.py
+++ b/tests/test_models/test_language_models/test_ngram_language_model.py
@@ -42,5 +42,5 @@ def test_ngram_language_model():
     assert 0 <= prob <= 1
 
     generation, prob = sampler.complete("x")
-    assert generation == "x" # unknown token is not appended
-    assert prob == 1 # 2**0
+    assert generation == "x"  # unknown token is not appended
+    assert prob == 1  # 2**0

--- a/tests/test_models/test_language_models/test_transformer_language_model.py
+++ b/tests/test_models/test_language_models/test_transformer_language_model.py
@@ -70,6 +70,7 @@ def test_transformer_language_model_position_ids():
     pos_ids = model._make_position_ids(token_ids)
     assert pos_ids[..., 0] == 0
 
+
 def test_transformer_language_model_predict_next():
     model = get_tlm_model()
     model.next(["<sos>"])

--- a/tests/test_models/test_model_utils.py
+++ b/tests/test_models/test_model_utils.py
@@ -21,8 +21,8 @@ def test_lr_scheduling():
     plot_lr_scheduler(
         lr_scheduler_class=FullyLambdaLR,
         initial_lr=0.01,
-        n_steps=len(wave)-1,
+        n_steps=len(wave) - 1,
         lr_lambda=(lambda step_num, base_lr, last_lr: wave[step_num]),
         save_fig=True,
-        fig_name="temp_wave.png"
+        fig_name="temp_wave.png",
     )

--- a/tests/test_text/test_tagger.py
+++ b/tests/test_text/test_tagger.py
@@ -1,4 +1,4 @@
-from sign_language_translator.text.tagger import Tagger, Rule, Tags
+from sign_language_translator.text.tagger import Rule, Tagger, Tags
 
 
 def get_tagger():

--- a/tests/test_text/test_text_utils.py
+++ b/tests/test_text/test_text_utils.py
@@ -1,7 +1,7 @@
 from sign_language_translator.text.utils import (
+    ListRegex,
     extract_supported_subsequences,
     make_ngrams,
-    ListRegex,
 )
 
 
@@ -43,7 +43,7 @@ def test_list_regex():
         [
             r"(abc|cba)",
             [r"jk", r"lmno?"],
-            ("123", (0, 2)), # test for max_count=0
+            ("123", (0, 2)),  # test for max_count=0
         ],
     )
     assert span == (0, 4)

--- a/tests/test_text/test_tokenizer.py
+++ b/tests/test_text/test_tokenizer.py
@@ -1,4 +1,5 @@
 import string
+
 from sign_language_translator.text.tokenizer import SignTokenizer
 
 
@@ -77,9 +78,23 @@ def test_join_subwords():
     expected_joint = ["ice-cream", " ", "from", " ", "book shop"]
     assert tokenizer._join_subwords(tokens) == expected_joint
 
+
 def test_join_word_sense():
     tokenizer = get_tokenizer()
 
-    tokens = ["this", " ", "is", " ", "a", "spring", "(", "metal", "-", "coil", ")", "."]
+    tokens = [
+        "this",
+        " ",
+        "is",
+        " ",
+        "a",
+        "spring",
+        "(",
+        "metal",
+        "-",
+        "coil",
+        ")",
+        ".",
+    ]
     expected_joint = ["this", " ", "is", " ", "a", "spring(metal-coil)", "."]
     assert tokenizer._join_word_sense(tokens) == expected_joint

--- a/tests/test_utils/test_arrays.py
+++ b/tests/test_utils/test_arrays.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from sign_language_translator.utils import linear_interpolation, ArrayOps
+from sign_language_translator.utils import ArrayOps, linear_interpolation
 
 
 def test_linear_interpolation():
@@ -42,7 +42,7 @@ def test_linear_interpolation():
             ],
         ]
     )
-    assert (np.abs(new_array - expected_array)<1e-4).all()
+    assert (np.abs(new_array - expected_array) < 1e-4).all()
 
     # test intermediate rows
     old_x = np.array([3, 5, 9])
@@ -81,4 +81,3 @@ def test_array_ops():
 
     ArrayOps.floor(tensor)
     ArrayOps.floor(array)
-

--- a/tests/test_vision/test_video.py
+++ b/tests/test_vision/test_video.py
@@ -57,6 +57,7 @@ def test_video_iteration():
     assert (base.numpy() == frames).all()
     assert base.torch() is not None
 
+
 # def test_video_display():
 #     pass
 

--- a/tests/test_vision_utils.py
+++ b/tests/test_vision_utils.py
@@ -1,7 +1,8 @@
-import numpy as np
 import cv2
+import numpy as np
 
 from sign_language_translator.vision.utils import iter_frames_with_opencv
+
 
 def test_image_iteration():
     # create and save image


### PR DESCRIPTION
- Replaced `| None` type hinting with `typing.Optional`
- Replaced `|` type unions with `typing.Union`
- Used `python 3.8` syntax and added support for `python>=3.8,<3.12`