### PR TITLE
Update download.py - Handling the zero division error

### DIFF
--- a/sign_language_translator/utils/download.py
+++ b/sign_language_translator/utils/download.py
@@ -88,7 +88,11 @@ def download(
                     fp.write(chunk)
 
                 # Calculate download speed (exponential moving average)
-                speed += len(chunk) / (1024**2) / (time() - start_time)
+                elapsed_time = time() - start_time
+                if elapsed_time==0:
+                    speed += 0
+                else:
+                    speed += len(chunk) / (1024**2) / (time() - start_time)
                 speed /= 2
                 start_time = time()
 


### PR DESCRIPTION
The code on execution caused zero division error because the (time() - start_time) was having value of zero (for very high speed internet download time is very close to zero) and the zero division error arose when calculating the speed using the equation speed += len(chunk) / (1024**2) / (time() - start_time), hence solved it by adding a check to verify that (time() - start_time) != 0